### PR TITLE
Django view decorator

### DIFF
--- a/manifoldco_signature/django.py
+++ b/manifoldco_signature/django.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+from django.http import JsonResponse
+from . import Verifier
+
+
+def verify(master_key=None):
+    """
+    Verify that the given request was sent from Manifold:
+
+    @verify()
+    def my_view(request):
+        pass
+
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(request, *args, **kwds):
+            verifier = Verifier(master_key=master_key)
+
+            headers = {}
+            for key, value in request.META.items():
+                if key == "CONTENT_TYPE":
+                    headers["content-type"] = value
+                elif key == "CONTENT_LENGTH":
+                    headers["content-length"] = value
+                elif key.startswith("HTTP_"):
+                    headers[key[5:].lower().replace("_", "-")] = value
+
+            if not verifier.verify(request.method, request.path,
+                                   request.GET, headers, request.body):
+                return JsonResponse(status=401,
+                                    data={"message": "Bad signature"})
+
+            return f(request, *args, **kwds)
+        return wrapper
+    return decorator

--- a/manifoldco_signature/django.py
+++ b/manifoldco_signature/django.py
@@ -1,50 +1,52 @@
 from functools import wraps
 
+from django.conf import settings
 from django.http import JsonResponse
 from . import Verifier
 
 
-def verify(master_key=None):
+def verify(f):
     """
     Verify that the given request was sent from Manifold:
 
-    @verify()
+    @verify
     def my_view(request):
         pass
 
     """
 
-    def decorator(f):
-        @wraps(f)
-        def wrapper(request, *args, **kwds):
-            verifier = Verifier(master_key=master_key)
+    @wraps(f)
+    def wrapper(request, *args, **kwds):
+        if hasattr(settings, "MANIFOLD_MASTER_KEY"):
+            verifier = Verifier(settings.MANIFOLD_MASTER_KEY)
+        else:
+            verifier = Verifier()
 
-            headers = {}
-            querydict = None
-            for key, value in request.META.items():
-                if key == "CONTENT_TYPE":
-                    headers["content-type"] = value
-                elif key == "CONTENT_LENGTH":
-                    headers["content-length"] = value
-                elif key.startswith("HTTP_"):
-                    headers[key[5:].lower().replace("_", "-")] = value
-                elif key == "QUERY_STRING" and value:
-                    # Cannot use request.GET here because need
-                    # unescaped values
-                    pairs = value.split("&")
-                    querydict = dict(pair.split("=") for pair in pairs)
+        headers = {}
+        querydict = None
+        for key, value in request.META.items():
+            if key == "CONTENT_TYPE":
+                headers["content-type"] = value
+            elif key == "CONTENT_LENGTH":
+                headers["content-length"] = value
+            elif key.startswith("HTTP_"):
+                headers[key[5:].lower().replace("_", "-")] = value
+            elif key == "QUERY_STRING" and value:
+                # Cannot use request.GET here because need
+                # unescaped values
+                pairs = value.split("&")
+                querydict = dict(pair.split("=") for pair in pairs)
 
-            kwargs = {
-                "method": request.method,
-                "path": request.path,
-                "query": querydict,
-                "headers": headers,
-                "body": request.body
-            }
-            if not verifier.verify(**kwargs):
-                return JsonResponse(status=401,
-                                    data={"message": "Bad signature"})
+        kwargs = {
+            "method": request.method,
+            "path": request.path,
+            "query": querydict,
+            "headers": headers,
+            "body": request.body
+        }
+        if not verifier.verify(**kwargs):
+            return JsonResponse(status=401,
+                                data={"message": "Bad signature"})
 
-            return f(request, *args, **kwds)
-        return wrapper
-    return decorator
+        return f(request, *args, **kwds)
+    return wrapper


### PR DESCRIPTION
A Django decorator that verifies signatures of requests coming from Manifold. Usage:

```
from manifoldco_signature.django import verify
    
@verify()
def my_view(request):
    pass

```

If the signature is valid, the view executes as normal. If the signature is not valid, the decorator returns  `{"message": "Bad signature"}` with status code 401

This doesn't have any tests at the moment. Test cases would probably need to mock `django.http.JsonResponse` and `manifoldco_signature.Verifier`. Would it be OK to add mock library in setup.py extra requirements?